### PR TITLE
fix(module): initialize array correctly

### DIFF
--- a/FormTemplateProcessorMailer.module
+++ b/FormTemplateProcessorMailer.module
@@ -191,7 +191,7 @@ class FormTemplateProcessorMailer extends WireData implements Module {
 	*/
 	protected function ___sendEmail($form) {
 
-		$inputsAry = '';
+		$inputsAry = array();
 		$fromName = '';
 		$fromAddress = '';
 		$subject = '';


### PR DESCRIPTION
E-mails were sent without content on PHP 7 for me. It turned out to be because of array being initialized as a string.  